### PR TITLE
feat: add admin dashboard and client QR page

### DIFF
--- a/admin-property.html
+++ b/admin-property.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Propiedad</title>
+<script src="https://cdn.tailwindcss.com/3.4.16"></script>
+</head>
+<body class="bg-gray-50 min-h-screen">
+<div class="max-w-3xl mx-auto p-6 space-y-6">
+  <div class="flex justify-between items-center">
+    <h1 id="prop-name" class="text-2xl font-bold"></h1>
+    <button id="logout" class="text-sm text-primary">Salir</button>
+  </div>
+  <div>
+    <label class="block text-sm mb-1">URL QR</label>
+    <div class="flex space-x-2">
+      <input id="qr-url" class="flex-grow border rounded p-2" readonly>
+      <button id="copy-qr" class="px-3 py-2 bg-primary text-white rounded">Copiar</button>
+    </div>
+  </div>
+  <section>
+    <h2 class="text-xl font-semibold mb-2">Tickets</h2>
+    <ul id="ticket-list" class="space-y-2"></ul>
+  </section>
+  <section>
+    <h2 class="text-xl font-semibold mb-2">Eventos</h2>
+    <form id="event-form" class="space-y-2 mb-4">
+      <input id="event-title" class="w-full border rounded p-2" placeholder="Título">
+      <input id="event-date" type="date" class="w-full border rounded p-2">
+      <button class="px-3 py-2 bg-primary text-white rounded" type="submit">Guardar</button>
+    </form>
+    <ul id="event-list" class="space-y-1"></ul>
+  </section>
+  <section>
+    <h2 class="text-xl font-semibold mb-2">Transporte</h2>
+    <form id="transport-form" class="space-y-2">
+      <input name="taxi" class="w-full border rounded p-2" placeholder="Taxi URL">
+      <input name="privateTaxi" class="w-full border rounded p-2" placeholder="Private Taxi URL">
+      <input name="bus" class="w-full border rounded p-2" placeholder="Bus URL">
+      <button class="px-3 py-2 bg-primary text-white rounded" type="submit">Guardar</button>
+    </form>
+  </section>
+</div>
+<script type="module" src="./js/admin-property.js"></script>
+</body>
+</html>

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Admin Dashboard</title>
+<script src="https://cdn.tailwindcss.com/3.4.16"></script>
+</head>
+<body class="bg-gray-50 min-h-screen">
+<div class="max-w-5xl mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-4">Propiedades</h1>
+  <div class="mb-4 flex justify-end">
+    <button id="logout" class="text-sm text-primary">Salir</button>
+  </div>
+  <div id="property-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
+</div>
+<script type="module" src="./js/admin.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -329,8 +329,8 @@ adminLoginForm.addEventListener('submit', (e) => {
 e.preventDefault();
 const password = document.getElementById('admin-password').value;
 if (password === 'admin123') {
-showScreen(adminDashboard);
-document.getElementById('admin-password').value = '';
+localStorage.setItem('isAdmin','true');
+window.location.href = 'admin.html';
 } else {
 const notification = document.createElement('div');
 notification.className = 'fixed top-20 left-1/2 transform -translate-x-1/2 bg-red-500 text-white px-6 py-3 rounded-md shadow-lg z-50';

--- a/js/admin-property.js
+++ b/js/admin-property.js
@@ -1,0 +1,106 @@
+import {
+  requireAdmin,
+  getProperty,
+  ticketsByProperty,
+  updateTicketStatus,
+  addEvent,
+  eventsByProperty,
+  updateProperty,
+  adminLogout
+} from './storage.js';
+
+requireAdmin();
+
+const params = new URLSearchParams(window.location.search);
+const id = params.get('id');
+const property = getProperty(id);
+
+if (!property) {
+  document.body.innerHTML = '<p>Propiedad no encontrada</p>';
+} else {
+  document.getElementById('prop-name').textContent = property.name;
+  const qr = `${window.location.origin}/p.html?id=${property.id}&t=${property.token}`;
+  const qrInput = document.getElementById('qr-url');
+  qrInput.value = qr;
+  document.getElementById('copy-qr').addEventListener('click', () => {
+    navigator.clipboard.writeText(qr);
+    alert('URL copiada');
+  });
+
+  // Tickets
+  const ticketList = document.getElementById('ticket-list');
+  function renderTickets() {
+    ticketList.innerHTML = '';
+    ticketsByProperty(id).forEach(t => {
+      const li = document.createElement('li');
+      li.className = 'bg-white p-3 rounded shadow';
+      li.innerHTML = `
+        <div class="flex justify-between">
+          <div>
+            <p class="font-medium">${t.title}</p>
+            <p class="text-sm text-gray-600">${t.notes}</p>
+          </div>
+          <select data-id="${t.id}" class="border rounded">
+            <option value="open">Abierto</option>
+            <option value="in-progress">En proceso</option>
+            <option value="closed">Cerrado</option>
+          </select>
+        </div>`;
+      li.querySelector('select').value = t.status || 'open';
+      ticketList.appendChild(li);
+    });
+  }
+  renderTickets();
+  ticketList.addEventListener('change', e => {
+    if (e.target.tagName === 'SELECT') {
+      const tid = e.target.getAttribute('data-id');
+      updateTicketStatus(tid, e.target.value);
+    }
+  });
+
+  // Events
+  const eventForm = document.getElementById('event-form');
+  const eventList = document.getElementById('event-list');
+  function renderEvents() {
+    eventList.innerHTML = '';
+    eventsByProperty(id)
+      .sort((a, b) => new Date(a.dateISO) - new Date(b.dateISO))
+      .forEach(e => {
+        const li = document.createElement('li');
+        li.textContent = `${e.title} - ${new Date(e.dateISO).toLocaleDateString()}`;
+        eventList.appendChild(li);
+      });
+  }
+  renderEvents();
+  eventForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const title = document.getElementById('event-title').value.trim();
+    const date = document.getElementById('event-date').value;
+    if (title && date) {
+      addEvent({ id: Date.now().toString(), propertyId: id, title, dateISO: date });
+      eventForm.reset();
+      renderEvents();
+    }
+  });
+
+  // Transport
+  const transportForm = document.getElementById('transport-form');
+  transportForm.taxi.value = property.transport?.taxi || '';
+  transportForm.privateTaxi.value = property.transport?.privateTaxi || '';
+  transportForm.bus.value = property.transport?.bus || '';
+  transportForm.addEventListener('submit', e => {
+    e.preventDefault();
+    property.transport = {
+      taxi: transportForm.taxi.value,
+      privateTaxi: transportForm.privateTaxi.value,
+      bus: transportForm.bus.value
+    };
+    updateProperty(property);
+    alert('Transporte guardado');
+  });
+}
+
+document.getElementById('logout').addEventListener('click', () => {
+  adminLogout();
+  window.location.href = 'index.html';
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,34 @@
+import { requireAdmin, loadProperties, adminLogout } from './storage.js';
+
+requireAdmin();
+
+const grid = document.getElementById('property-grid');
+const props = loadProperties();
+
+props.forEach(p => {
+  const card = document.createElement('div');
+  card.className = 'bg-white rounded-lg shadow p-4 flex flex-col';
+  const qrUrl = `${window.location.origin}/p.html?id=${p.id}&t=${p.token}`;
+  card.innerHTML = `
+    <h3 class="text-lg font-semibold mb-2">${p.name}</h3>
+    <div class="mt-auto flex justify-between items-center">
+      <a href="admin-property.html?id=${p.id}" class="text-primary">Ajustes</a>
+      <button class="text-sm text-gray-500 copy" data-url="${qrUrl}">Copiar QR</button>
+    </div>
+  `;
+  grid.appendChild(card);
+});
+
+grid.addEventListener('click', e => {
+  if (e.target.classList.contains('copy')) {
+    const url = e.target.getAttribute('data-url');
+    navigator.clipboard.writeText(url).then(() => {
+      alert('URL copiada');
+    });
+  }
+});
+
+document.getElementById('logout').addEventListener('click', () => {
+  adminLogout();
+  window.location.href = 'index.html';
+});

--- a/js/property.js
+++ b/js/property.js
@@ -1,0 +1,91 @@
+import { getProperty, addTicket, eventsByProperty } from './storage.js';
+
+const params = new URLSearchParams(window.location.search);
+const id = params.get('id');
+const token = params.get('t');
+const property = getProperty(id);
+
+if (!property || property.token !== token) {
+  document.body.innerHTML = '<p class="p-4">Acceso denegado</p>';
+} else {
+  document.getElementById('top-bar').style.backgroundColor = property.themeColor;
+  document.getElementById('logo').src = property.logoUrl;
+  document.getElementById('description').textContent = property.description;
+  document.getElementById('address').textContent = property.address;
+  const email = document.getElementById('email');
+  email.textContent = property.contactEmail;
+  email.href = `mailto:${property.contactEmail}`;
+
+  // Buttons
+  document.getElementById('btn-repairs').addEventListener('click', () => showForm('repair'));
+  document.getElementById('btn-cleaning').addEventListener('click', () => showForm('cleaning'));
+  document.getElementById('btn-transport').addEventListener('click', showTransport);
+  document.getElementById('btn-events').addEventListener('click', showEvents);
+
+  function showForm(type) {
+    document.getElementById('transport').classList.add('hidden');
+    document.getElementById('events').classList.add('hidden');
+    const forms = document.getElementById('forms');
+    forms.innerHTML = '';
+    const form = document.createElement('form');
+    form.className = 'space-y-2';
+    form.innerHTML = `
+      <input class="w-full border rounded p-2" name="title" placeholder="Título">
+      <textarea class="w-full border rounded p-2" name="notes" placeholder="Notas"></textarea>
+      <button class="px-3 py-2 bg-primary text-white rounded" type="submit">Enviar</button>
+    `;
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const data = new FormData(form);
+      const ticket = {
+        id: Date.now().toString(),
+        propertyId: id,
+        type: type === 'repair' ? 'repair' : 'cleaning',
+        title: data.get('title'),
+        notes: data.get('notes'),
+        status: 'open'
+      };
+      addTicket(ticket);
+      alert('Enviado');
+      form.reset();
+    });
+    forms.appendChild(form);
+  }
+
+  function showTransport() {
+    const tDiv = document.getElementById('transport');
+    tDiv.classList.remove('hidden');
+    document.getElementById('events').classList.add('hidden');
+    document.getElementById('forms').innerHTML = '';
+    tDiv.innerHTML = '';
+    const cats = [
+      { key: 'taxi', label: 'Taxi' },
+      { key: 'privateTaxi', label: 'Private Taxi' },
+      { key: 'bus', label: 'Bus' }
+    ];
+    cats.forEach(c => {
+      const url = property.transport?.[c.key];
+      const btn = document.createElement('a');
+      btn.className = 'block bg-gray-200 p-4 rounded text-center';
+      btn.textContent = c.label;
+      btn.href = url || '#';
+      if (!url) btn.addEventListener('click', e => e.preventDefault());
+      tDiv.appendChild(btn);
+    });
+  }
+
+  function showEvents() {
+    const eDiv = document.getElementById('events');
+    eDiv.classList.remove('hidden');
+    document.getElementById('transport').classList.add('hidden');
+    document.getElementById('forms').innerHTML = '';
+    eDiv.innerHTML = '';
+    eventsByProperty(id)
+      .sort((a, b) => new Date(a.dateISO) - new Date(b.dateISO))
+      .forEach(ev => {
+        const p = document.createElement('p');
+        p.textContent = `${ev.title} - ${new Date(ev.dateISO).toLocaleDateString()}`;
+        eDiv.appendChild(p);
+      });
+  }
+}

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,0 +1,109 @@
+export const defaultProperties = [
+  {
+    id: '1',
+    name: 'Prop1',
+    logoUrl: 'https://via.placeholder.com/80',
+    themeColor: '#1e3a8a',
+    address: 'Calle 1, Ibiza',
+    contactEmail: 'prop1@example.com',
+    token: 'token1',
+    description: 'Bienvenido a Prop1',
+    transport: { taxi: '', privateTaxi: '', bus: '' }
+  },
+  {
+    id: '2',
+    name: 'Prop2',
+    logoUrl: 'https://via.placeholder.com/80',
+    themeColor: '#047857',
+    address: 'Calle 2, Ibiza',
+    contactEmail: 'prop2@example.com',
+    token: 'token2',
+    description: 'Bienvenido a Prop2',
+    transport: { taxi: '', privateTaxi: '', bus: '' }
+  }
+];
+
+export function loadProperties() {
+  let props = JSON.parse(localStorage.getItem('properties'));
+  if (!props || props.length === 0) {
+    props = defaultProperties;
+    localStorage.setItem('properties', JSON.stringify(props));
+  }
+  return props;
+}
+
+export function saveProperties(props) {
+  localStorage.setItem('properties', JSON.stringify(props));
+}
+
+export function getProperty(id) {
+  return loadProperties().find(p => p.id === id);
+}
+
+export function updateProperty(updated) {
+  const props = loadProperties().map(p => (p.id === updated.id ? updated : p));
+  saveProperties(props);
+}
+
+export function loadTickets() {
+  return JSON.parse(localStorage.getItem('tickets')) || [];
+}
+
+export function saveTickets(tickets) {
+  localStorage.setItem('tickets', JSON.stringify(tickets));
+}
+
+export function addTicket(ticket) {
+  const arr = loadTickets();
+  arr.push(ticket);
+  saveTickets(arr);
+}
+
+export function updateTicketStatus(id, status) {
+  const arr = loadTickets();
+  const t = arr.find(t => t.id === id);
+  if (t) {
+    t.status = status;
+    saveTickets(arr);
+  }
+}
+
+export function ticketsByProperty(propId) {
+  return loadTickets().filter(t => t.propertyId === propId);
+}
+
+export function loadEvents() {
+  return JSON.parse(localStorage.getItem('events')) || [];
+}
+
+export function saveEvents(events) {
+  localStorage.setItem('events', JSON.stringify(events));
+}
+
+export function addEvent(event) {
+  const arr = loadEvents();
+  arr.push(event);
+  saveEvents(arr);
+}
+
+export function eventsByProperty(propId) {
+  return loadEvents().filter(e => e.propertyId === propId);
+}
+
+export function requireAdmin() {
+  if (localStorage.getItem('isAdmin') !== 'true') {
+    window.location.href = 'index.html';
+  }
+}
+
+export function adminLogin(password) {
+  if (password === 'admin123') {
+    localStorage.setItem('isAdmin', 'true');
+    return true;
+  }
+  return false;
+}
+
+export function adminLogout() {
+  localStorage.removeItem('isAdmin');
+}

--- a/p.html
+++ b/p.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Ibiza Fix</title>
+<script src="https://cdn.tailwindcss.com/3.4.16"></script>
+</head>
+<body class="min-h-screen flex flex-col">
+<header id="top-bar" class="text-white p-4 flex justify-between items-center">
+  <span class="font-bold">Ibiza Fix</span>
+  <img id="logo" class="h-8" alt="logo">
+</header>
+<div class="p-4">
+  <p id="description" class="mb-4 text-center"></p>
+  <div id="main-grid" class="grid grid-cols-2 gap-4 mb-6">
+    <button id="btn-repairs" class="bg-gray-200 py-8 rounded text-lg font-medium">Averías</button>
+    <button id="btn-cleaning" class="bg-gray-200 py-8 rounded text-lg font-medium">Limpieza</button>
+    <button id="btn-transport" class="bg-gray-200 py-8 rounded text-lg font-medium">Transp.</button>
+    <button id="btn-events" class="bg-gray-200 py-8 rounded text-lg font-medium">Otros</button>
+  </div>
+  <div id="forms" class="space-y-4"></div>
+  <div id="transport" class="hidden space-y-2"></div>
+  <div id="events" class="hidden space-y-1"></div>
+</div>
+<footer class="mt-auto p-4 text-center text-sm text-gray-600 space-y-1">
+  <div id="address"></div>
+  <div><a id="email" class="underline"></a></div>
+  <button id="support" class="mt-2 px-4 py-2 bg-gray-200 rounded">Soporte</button>
+</footer>
+<a id="chat" class="fixed bottom-4 right-4 bg-green-500 text-white p-3 rounded-full" href="https://wa.me/" target="_blank">WA</a>
+<script type="module" src="./js/property.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add developer dashboard with property grid and copyable QR links
- provide per-property settings page for tickets, events, and transport options
- add client-facing QR page with repair/cleaning forms, transport options, and events

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cb0ee140832dac8a92bdafc686ae