### PR TITLE
feat: endpoint interno para crear incidencias con validación y anti-abuso

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ Este repositorio contiene la página web para que los huéspedes de CH GROUP pue
 4. Verás un mensaje de confirmación con el tiempo máximo de espera de dos días.
 
 La web está optimizada para dispositivos móviles, por lo que se recomienda escanear el código QR disponible en cada habitación para acceder rápidamente al formulario.
+
+## API interna de incidencias
+
+Se añadió un endpoint interno `POST /api/public/incidents` (estilo Next.js Route Handler) con:
+
+- Validación de payload con Zod (`category`, `severity`, `message`, `contact` opcional y `token` obligatorio).
+- Generación de referencia en servidor (`INC-YYYYMMDD-#####`).
+- Persistencia en una base de datos JSON local (`data/incidents-db.json`).
+- Registro de estado inicial en `incident_status_history` con estado `NEW`.
+- Protección anti-abuso básica: rate limiting por IP/token + honeypot (`website`) + cooldown (`submittedAt`).

--- a/app/api/public/incidents/route.ts
+++ b/app/api/public/incidents/route.ts
@@ -1,0 +1,127 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+
+import { createIncident } from '../../../../lib/server/incidents-store';
+
+const incidentPayloadSchema = z
+  .object({
+    category: z.string().trim().min(1).max(100),
+    severity: z.enum(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']),
+    message: z.string().trim().min(5).max(2000),
+    contact: z.string().trim().max(150).optional(),
+    token: z.string().trim().min(8).max(128),
+    website: z.string().optional(), // honeypot
+    submittedAt: z.coerce.number().optional(), // anti-bot cooldown
+  })
+  .strict();
+
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const RATE_LIMIT_BY_IP = 15;
+const RATE_LIMIT_BY_TOKEN = 8;
+const SUBMISSION_COOLDOWN_MS = 5_000;
+
+const requestLogByIp = new Map<string, number[]>();
+const requestLogByToken = new Map<string, number[]>();
+
+function cleanupAndCount(map: Map<string, number[]>, key: string, now: number): number {
+  const entries = map.get(key) ?? [];
+  const validEntries = entries.filter((ts) => now - ts <= RATE_LIMIT_WINDOW_MS);
+  map.set(key, validEntries);
+  return validEntries.length;
+}
+
+function registerHit(map: Map<string, number[]>, key: string, now: number): void {
+  const entries = map.get(key) ?? [];
+  entries.push(now);
+  map.set(key, entries);
+}
+
+function getClientIp(request: Request): string {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  if (forwardedFor) {
+    return forwardedFor.split(',')[0].trim();
+  }
+
+  return request.headers.get('x-real-ip') ?? '0.0.0.0';
+}
+
+function hashToken(rawToken: string): string {
+  return createHash('sha256').update(rawToken).digest('hex');
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const now = Date.now();
+  const clientIp = getClientIp(request);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Payload JSON inválido.' }, { status: 400 });
+  }
+
+  const parsed = incidentPayloadSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      {
+        error: 'Validación fallida.',
+        issues: parsed.error.issues,
+      },
+      { status: 400 },
+    );
+  }
+
+  const { website, submittedAt, token, ...incidentInput } = parsed.data;
+
+  if (website && website.trim().length > 0) {
+    return Response.json({ error: 'Solicitud rechazada.' }, { status: 400 });
+  }
+
+  if (submittedAt && now - submittedAt < SUBMISSION_COOLDOWN_MS) {
+    return Response.json(
+      { error: 'Espera unos segundos antes de enviar la incidencia.' },
+      { status: 429 },
+    );
+  }
+
+  const tokenKey = hashToken(token);
+  const ipCount = cleanupAndCount(requestLogByIp, clientIp, now);
+  const tokenCount = cleanupAndCount(requestLogByToken, tokenKey, now);
+
+  if (ipCount >= RATE_LIMIT_BY_IP || tokenCount >= RATE_LIMIT_BY_TOKEN) {
+    return Response.json(
+      {
+        error: 'Demasiadas solicitudes. Inténtalo más tarde.',
+        retryAfterSeconds: Math.ceil(RATE_LIMIT_WINDOW_MS / 1000),
+      },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(Math.ceil(RATE_LIMIT_WINDOW_MS / 1000)),
+        },
+      },
+    );
+  }
+
+  registerHit(requestLogByIp, clientIp, now);
+  registerHit(requestLogByToken, tokenKey, now);
+
+  const { incident, initialStatus } = await createIncident({
+    ...incidentInput,
+    token,
+    ip: clientIp,
+  });
+
+  return Response.json(
+    {
+      ok: true,
+      incident: {
+        id: incident.id,
+        reference: incident.reference,
+        status: initialStatus.status,
+        createdAt: incident.createdAt,
+      },
+    },
+    { status: 201 },
+  );
+}

--- a/data/incidents-db.json
+++ b/data/incidents-db.json
@@ -1,0 +1,4 @@
+{
+  "incidents": [],
+  "incident_status_history": []
+}

--- a/lib/server/incidents-store.ts
+++ b/lib/server/incidents-store.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const DATA_DIR = path.join(process.cwd(), 'data');
+const DB_PATH = path.join(DATA_DIR, 'incidents-db.json');
+
+type IncidentStatus = 'NEW' | 'IN_PROGRESS' | 'RESOLVED' | 'CLOSED';
+
+export interface IncidentRecord {
+  id: string;
+  reference: string;
+  category: string;
+  severity: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+  message: string;
+  contact: string | null;
+  token: string;
+  createdAt: string;
+  createdFromIp: string;
+}
+
+export interface IncidentStatusHistoryRecord {
+  id: string;
+  incidentId: string;
+  status: IncidentStatus;
+  note: string;
+  createdAt: string;
+}
+
+interface IncidentDatabase {
+  incidents: IncidentRecord[];
+  incident_status_history: IncidentStatusHistoryRecord[];
+}
+
+const DEFAULT_DB: IncidentDatabase = {
+  incidents: [],
+  incident_status_history: [],
+};
+
+async function ensureDbFile(): Promise<void> {
+  await mkdir(DATA_DIR, { recursive: true });
+
+  try {
+    await readFile(DB_PATH, 'utf8');
+  } catch {
+    await writeFile(DB_PATH, JSON.stringify(DEFAULT_DB, null, 2), 'utf8');
+  }
+}
+
+async function readDb(): Promise<IncidentDatabase> {
+  await ensureDbFile();
+  const raw = await readFile(DB_PATH, 'utf8');
+
+  try {
+    return JSON.parse(raw) as IncidentDatabase;
+  } catch {
+    return structuredClone(DEFAULT_DB);
+  }
+}
+
+async function writeDb(db: IncidentDatabase): Promise<void> {
+  await ensureDbFile();
+  await writeFile(DB_PATH, JSON.stringify(db, null, 2), 'utf8');
+}
+
+function buildIncidentReference(now: Date): string {
+  const yyyymmdd = now.toISOString().slice(0, 10).replaceAll('-', '');
+  const suffix = Math.floor(Math.random() * 100000)
+    .toString()
+    .padStart(5, '0');
+
+  return `INC-${yyyymmdd}-${suffix}`;
+}
+
+export async function createIncident(input: {
+  category: string;
+  severity: IncidentRecord['severity'];
+  message: string;
+  contact?: string;
+  token: string;
+  ip: string;
+}): Promise<{ incident: IncidentRecord; initialStatus: IncidentStatusHistoryRecord }> {
+  const now = new Date();
+  const db = await readDb();
+
+  const incident: IncidentRecord = {
+    id: randomUUID(),
+    reference: buildIncidentReference(now),
+    category: input.category,
+    severity: input.severity,
+    message: input.message,
+    contact: input.contact?.trim() ? input.contact.trim() : null,
+    token: input.token,
+    createdAt: now.toISOString(),
+    createdFromIp: input.ip,
+  };
+
+  const initialStatus: IncidentStatusHistoryRecord = {
+    id: randomUUID(),
+    incidentId: incident.id,
+    status: 'NEW',
+    note: 'Incidencia creada desde endpoint público.',
+    createdAt: now.toISOString(),
+  };
+
+  db.incidents.push(incident);
+  db.incident_status_history.push(initialStatus);
+  await writeDb(db);
+
+  return { incident, initialStatus };
+}


### PR DESCRIPTION
### Motivation
- Proveer un endpoint interno para crear incidencias con referencia generada en servidor y validación estricta del payload.
- Evitar abuso y envíos automáticos desde el formulario público mediante limitación básica y señales anti-bot.
- Mantener trazabilidad inicial de la incidencia guardando el estado original en el historial.

### Description
- Añade el handler `POST /api/public/incidents` en `app/api/public/incidents/route.ts` y valida el payload con `zod` para `category`, `severity`, `message`, `contact` opcional y `token` obligatorio.
- Implementa generación de referencia en servidor con formato `INC-YYYYMMDD-#####` y persistencia en un almacenamiento JSON local en `data/incidents-db.json` mediante `lib/server/incidents-store.ts`.
- Registra un evento inicial con estado `NEW` en `incident_status_history` al crear la incidencia.
- Introduce mitigaciones anti-abuso: rate limiting por IP y por token, honeypot `website` y cooldown basado en `submittedAt`.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbe5cfcd78832d94952047d2bde195)